### PR TITLE
Add process_seqstr in orca_predict.py

### DIFF
--- a/orca_predict.py
+++ b/orca_predict.py
@@ -3018,7 +3018,7 @@ def process_single_breakpoint(
 
 
 def process_seqstr(
-	seqstr_input,
+    seqstr_input,
     file=None,
     mpos=None,
     custom_models=None,


### PR DESCRIPTION
prcoess_seqstr(seqstr_input, file=None, mpos=None, custom_models=None, use_cuda=True)

 - The function extracts the sequence string (seqstrout) from input, such as '[hg38]chr9:94904000-126904000 +'
 - Sequence length needs to be at least 32Mb, if longer than 32Mb, only the middle 32Mb will be used.
 - Zoom in middle (16Mb) if mpos is not specified
 - Use selene_sdk.sequences Genome.sequence_to_encoding(sequence_str) to get encoding of sequence
 - Use genomepredict to predict multi-scale interaction
 - Use genomeplot to plot the results

Need [Seqstr package](https://github.com/jzhoulab/Seqstr) to use the function.

Try import seqstr in the beginning, if package not installed, calling the function will invoke ImportError.

Tested 3 seqstrs with 1, 2, and 3 segments, all generated pdf files
```python
teststr = '[hg38]chr9:94904000-126904000 +'
testout = process_region_seqstr(teststr, file="seqstr_test1")
teststr = '[hg38]chr9:94904000-100904000 +; chr7:5480600-32480600 -'
testout = process_region_seqstr(teststr, file="seqstr_test2")
teststr = '[hg38]chr9:94904000-100904000 +; chr7:5480600-13480600 -; chr1:10904000-75904000 +'
testout = process_region_seqstr(teststr, file="seqstr_test3")
```